### PR TITLE
✨ Feature: #92 앱 강제 종료 시 알람 미작동 경고 푸시 알림

### DIFF
--- a/T8-NoFrank/Sources/Models/BackgroundAudioPlayer.swift
+++ b/T8-NoFrank/Sources/Models/BackgroundAudioPlayer.swift
@@ -64,6 +64,10 @@ class BackgroundAudioPlayer: ObservableObject {
         self.selectedWeekdays = weekdays
         updateNextAlarmTime(hour: hour, minute: minute)
 
+        // 앱 재시작 시 이전 종료 경고 노티 즉시 취소
+        UNUserNotificationCenter.current()
+            .removePendingNotificationRequests(withIdentifiers: ["appTerminationWarning"])
+
         playSilentSound()
 
         // 1초마다 알람 시간 체크
@@ -153,9 +157,38 @@ class BackgroundAudioPlayer: ObservableObject {
         }
     }
 
+    // MARK: - App Termination Warning (Dead Man's Switch)
+    private func scheduleTerminationWarning() {
+        let center = UNUserNotificationCenter.current()
+        // 이전 경고 노티 취소 후 1초 뒤로 재예약
+        center.removePendingNotificationRequests(withIdentifiers: ["appTerminationWarning"])
+
+        let content = UNMutableNotificationContent()
+        content.title = "CRock"
+        content.body = "앱이 종료되었어요. 알람이 울리지 않을 수 있어요!"
+        content.sound = .default
+
+        let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 3, repeats: false)
+        let request = UNNotificationRequest(
+            identifier: "appTerminationWarning",
+            content: content,
+            trigger: trigger
+        )
+        center.add(request)
+    }
+
     // MARK: - Check Alarm Time
     private func checkAlarmTime() {
         guard let alarmTime = alarmTime else { return }
+
+        // 알람 울리는 중이 아닐 때만 종료 경고 노티 예약
+        if !isAlarmMode {
+            scheduleTerminationWarning()
+        } else {
+            // 알람 모드일 때는 경고 노티 취소
+            UNUserNotificationCenter.current()
+                .removePendingNotificationRequests(withIdentifiers: ["appTerminationWarning"])
+        }
 
         let now = Date()
 
@@ -245,6 +278,11 @@ class BackgroundAudioPlayer: ObservableObject {
         isPlaying = false
         isAlarmMode = false
         alarmTime = nil
+
+        // 알람 끄면 종료 경고 노티도 취소
+        UNUserNotificationCenter.current()
+            .removePendingNotificationRequests(withIdentifiers: ["appTerminationWarning"])
+
         print("🛑 Background audio player stopped")
     }
 }

--- a/T8-NoFrank/Sources/Models/NotificationExtension.swift
+++ b/T8-NoFrank/Sources/Models/NotificationExtension.swift
@@ -153,11 +153,19 @@ extension NotificationDelegate {
         // ✅ 앱이 보낸 알림 전부 제거
         center.removeAllDeliveredNotifications()  // 이미 온 알림 삭제
 
-        // 여기서 알람 화면 전환, 사운드 정지 등 원하는 로직 실행 가능
         print("알림 제거 완료")
 
-        Task { @MainActor in
-            AppRouter.shared.navigate(.breakingStone)
+        let id = response.notification.request.identifier
+
+        // 종료 경고 노티는 홈으로 이동
+        if id == "appTerminationWarning" {
+            Task { @MainActor in
+                AppRouter.shared.navigate(.home)
+            }
+        } else {
+            Task { @MainActor in
+                AppRouter.shared.navigate(.breakingStone)
+            }
         }
         completionHandler()
     }


### PR DESCRIPTION
## ✨ What's this PR?
### 📌 관련 이슈 (Related Issue)
- Closes #92

---

### 🧶 주요 변경 내용 (Summary)

#### 앱 강제 종료 시 경고 푸시 알림
- 알람 활성 상태에서 1초마다 3초 후 발송되는 종료 경고 노티를 재예약하는 방식으로, 앱이 종료되면 자동으로 경고 노티가 발송됨
- 알람 울리는 중(돌 깨기 화면)에는 경고 노티 미발송
- 경고 노티 탭 시 홈 화면으로 이동 (돌 깨기 화면 X)
- 앱 재시작 시 이전 경고 노티 즉시 취소
- 알람 끌 때 경고 노티도 함께 취소

---

### 🧪 테스트 / 검증 내역

- [x] 알람 활성 상태에서 앱 강제 종료 시 경고 노티 수신 확인
- [x] 알람 울리는 중 앱 종료 시 경고 노티 미발송 확인
- [x] 경고 노티 탭 시 홈 화면 이동 확인
- [x] 앱 재시작 시 경고 노티 취소 확인
- [x] UI 정상 동작 확인
- [x] 핸드폰 빌드 후 확인