### PR TITLE
🐛 Bug: #103 앱 실행 중 종료 경고 알림 오발송 문제 수정

### DIFF
--- a/T8-NoFrank/Sources/App/T8_NoFrankApp.swift
+++ b/T8-NoFrank/Sources/App/T8_NoFrankApp.swift
@@ -33,6 +33,10 @@ struct T8_NoFrankApp: App {
                 if BackgroundAudioPlayer.shared.isAlarmMode {
                     router.navigate(.breakingStone)
                 }
+                // 오디오 세션 인터럽트(전화, 유튜브 등) 이후 복원
+                if BackgroundAudioPlayer.shared.isPlaying {
+                    BackgroundAudioPlayer.shared.restoreAudioSession()
+                }
             @unknown default:
                 break
             }

--- a/T8-NoFrank/Sources/Models/BackgroundAudioPlayer.swift
+++ b/T8-NoFrank/Sources/Models/BackgroundAudioPlayer.swift
@@ -25,6 +25,7 @@ class BackgroundAudioPlayer: ObservableObject {
 
     private init() {
         setupAudioSession()
+        setupInterruptionObserver()
     }
 
     // MARK: - System Volume Control
@@ -42,16 +43,58 @@ class BackgroundAudioPlayer: ObservableObject {
         return AVAudioSession.sharedInstance().outputVolume
     }
 
+    // MARK: - Audio Session Interruption Handling
+    private func setupInterruptionObserver() {
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleAudioInterruption),
+            name: AVAudioSession.interruptionNotification,
+            object: AVAudioSession.sharedInstance()
+        )
+    }
+
+    @objc private func handleAudioInterruption(notification: Notification) {
+        guard let userInfo = notification.userInfo,
+              let typeValue = userInfo[AVAudioSessionInterruptionTypeKey] as? UInt,
+              let type = AVAudioSession.InterruptionType(rawValue: typeValue)
+        else { return }
+
+        switch type {
+        case .began:
+            print("🔇 Audio session interrupted (phone call, Siri, etc.)")
+
+        case .ended:
+            guard let optionsValue = userInfo[AVAudioSessionInterruptionOptionKey] as? UInt else { return }
+            let options = AVAudioSession.InterruptionOptions(rawValue: optionsValue)
+
+            if options.contains(.shouldResume), isPlaying {
+                print("🔊 Audio session interruption ended - restoring")
+                restoreAudioSession()
+            }
+
+        @unknown default:
+            break
+        }
+    }
+
+    func restoreAudioSession() {
+        guard isPlaying else { return }
+        setupAudioSession()
+        audioPlayer?.play()
+        print("🔊 Audio session restored")
+    }
+
     // MARK: - Audio Session Setup
     private func setupAudioSession() {
         do {
             let audioSession = AVAudioSession.sharedInstance()
-            // playback: 백그라운드 재생 가능
-            // mixWithOthers: 다른 앱 오디오와 섞이지 않음
+            // mixWithOthers: 다른 앱(유튜브, 음악 등)이 재생 중에도 오디오 세션을 유지
+            // → 인터럽트로 인한 앱 Suspend를 방지하여 Dead Man's Switch 타이머가 멈추지 않음
+            // 무음(0.0) 재생이므로 다른 앱 오디오에 영향 없음
             try audioSession.setCategory(
                 .playback,
                 mode: .default,
-                options: []
+                options: [.mixWithOthers]
             )
             try audioSession.setActive(true)
             print("🔊 Audio session setup successful")

--- a/T8-NoFrank/Sources/Models/NotificationService.swift
+++ b/T8-NoFrank/Sources/Models/NotificationService.swift
@@ -52,6 +52,11 @@ final class NotificationDelegate: NSObject, UNUserNotificationCenterDelegate {
         withCompletionHandler completionHandler:
             @escaping (UNNotificationPresentationOptions) -> Void
     ) {
+        // 앱이 살아있는 상태에서는 종료 경고 알림을 표시하지 않음
+        if notification.request.identifier == "appTerminationWarning" {
+            completionHandler([])
+            return
+        }
         completionHandler([.banner, .list, .badge])
     }
 }


### PR DESCRIPTION
## ✨ What's this PR?
### 📌 관련 이슈 (Related Issue)
- Closes #103

---

### 🧶 주요 변경 내용 (Summary)

#### AVAudioSession에 mixWithOthers 옵션 추가
- 유튜브, 음악 앱 등 외부 앱이 오디오를 재생해도 우리 앱의 오디오 세션이 인터럽트되지 않도록 처리
- 세션 인터럽트 → 앱 Suspended → Dead Man's Switch 타이머 중단 → 오발송으로 이어지는 흐름 차단
- silent audio는 volume 0.0이므로 다른 앱 오디오에 영향 없음

#### AVAudioSession 인터럽트 핸들러 추가
- 전화 수신 등 시스템 레벨 인터럽트 종료 시 오디오 세션 자동 복원

#### scenePhase .active 시 오디오 세션 복원 처리
- 인터럽트 이후 앱 재진입 시 silent audio가 재생되지 않는 문제 방지

#### willPresent에서 appTerminationWarning 필터링
- 앱이 살아있는 상태에서 포그라운드 진입 시 종료 경고 알림이 표시되지 않도록 차단

---
### ⚠️ 필독: 전화 수신 케이스 미해결

현재 PR은 **유튜브/음악 앱 등 일반 앱 간섭**으로 인한 오발송을 수정합니다.
**전화 수신 시에는 여전히 오발송이 발생할 수 있습니다.**
전화수신시 노티가 발송되어도 알람은 정상적으로 작동합니다

---
### 🧪 테스트 / 검증 내역

- [x] 알람 활성화 후 백그라운드 진입 → 유튜브 뮤직 재생/일시정지 시 오발송 없음 확인
- [x] 알람 활성화 후 백그라운드 진입 → 유튜브 뮤직 종료 후 앱 재진입 → 다시 백그라운드 진입 시 오발송 없음 확인
- [x] 앱 강제종료 시 정상적으로 종료 경고 알림 수신 확인
- [x] UI 정상 동작 확인
- [x] 핸드폰 빌드 후 확인