### PR TITLE
✨ Feature: #104 강제 종료 후 알람 상태 복원 및 burst 노티

### DIFF
--- a/T8-NoFrank/Sources/App/T8_NoFrankApp.swift
+++ b/T8-NoFrank/Sources/App/T8_NoFrankApp.swift
@@ -31,6 +31,13 @@ struct T8_NoFrankApp: App {
             case .active:
                 print("앱이 포그라운드 상태")
                 if BackgroundAudioPlayer.shared.isAlarmMode {
+                    // 앱이 살아있는 상태에서 포그라운드 복귀 → 돌 깨기 화면 유지
+                    router.navigate(.breakingStone)
+                } else if BackgroundAudioPlayer.isAlarmRingingPersisted() {
+                    // 강제 종료 후 재실행 → 알람 상태 복원
+                    let player = BackgroundAudioPlayer.shared
+                    player.restoreOriginalVolumeFromPersistence()
+                    player.playAlarmSound()
                     router.navigate(.breakingStone)
                 }
                 // 오디오 세션 인터럽트(전화, 유튜브 등) 이후 복원

--- a/T8-NoFrank/Sources/Models/BackgroundAudioPlayer.swift
+++ b/T8-NoFrank/Sources/Models/BackgroundAudioPlayer.swift
@@ -22,6 +22,15 @@ class BackgroundAudioPlayer: ObservableObject {
     private var selectedWeekdays: Set<Int> = []
     private var originalSystemVolume: Float = 0.0
     private var volumeRestorationTimer: Timer?
+    private var lastBurstScheduleTime: Date?
+
+    private static let appGroupID = "group.CRockWidget"
+    private static let isAlarmRingingKey = "isAlarmRinging"
+    private static let alarmRingingTimestampKey = "alarmRingingTimestamp"
+    private static let originalVolumeKey = "originalSystemVolume"
+    private static let burstCount = 60
+    private static let burstIntervalSec: TimeInterval = 30
+    private static let burstIdentifierPrefix = "ALARM_BURST_"
 
     private init() {
         setupAudioSession()
@@ -147,31 +156,56 @@ class BackgroundAudioPlayer: ObservableObject {
     }
 
     // MARK: - Play Alarm Sound
-    private func playAlarmSound() {
+    func playAlarmSound() {
         // 저장된 볼륨 가져오기 (AppGroup 사용)
-        let appGroupID = "group.CRockWidget"
-        let savedVolume = UserDefaults(suiteName: appGroupID)?.double(forKey: "alarmVolume")
+        let savedVolume = UserDefaults(suiteName: Self.appGroupID)?.double(forKey: "alarmVolume")
 
         print("📊 Saved volume from UserDefaults: \(savedVolume ?? -1)")
 
         let targetVolume = Float(savedVolume ?? 1.0)
 
-        // 현재 시스템 볼륨 저장
+        // 현재 시스템 볼륨 저장 (재실행 복원용으로 UserDefaults에도 저장)
         originalSystemVolume = getCurrentSystemVolume()
+        UserDefaults(suiteName: Self.appGroupID)?.set(
+            Double(originalSystemVolume), forKey: Self.originalVolumeKey
+        )
         print("💾 Original system volume: \(Int(originalSystemVolume * 100))%")
 
         // 시스템 볼륨을 설정한 값으로 변경
         setSystemVolume(targetVolume)
 
+        // audioPlayer가 없으면 (강제 종료 후 재실행) 새로 생성
+        if audioPlayer == nil {
+            guard let soundURL = Bundle.main.url(forResource: "NotiSound28sec", withExtension: "caf") else {
+                print("❌ Sound file not found")
+                return
+            }
+            do {
+                audioPlayer = try AVAudioPlayer(contentsOf: soundURL)
+                audioPlayer?.numberOfLoops = -1
+                audioPlayer?.prepareToPlay()
+                audioPlayer?.play()
+            } catch {
+                print("❌ Failed to create audio player: \(error)")
+                return
+            }
+        }
+
         // 앱 내부 볼륨은 최대로 설정
         audioPlayer?.volume = 1.0
         isAlarmMode = true
+
+        // 알람 상태 영속화 (강제 종료 후 복원용)
+        persistAlarmRinging(true)
 
         // 2초마다 시스템 볼륨을 지정 볼륨으로 복원 (사용자가 볼륨 내리는 것 방지)
         startVolumeRestorationTimer(targetVolume: targetVolume)
 
         // 노티 1개만 전송
         sendLocalNotification()
+
+        // 강제 종료 대비 burst 노티 60개 예약
+        scheduleAlarmBurst()
 
         print("🔔 Alarm sound started (target volume: \(Int(targetVolume * 100))%)")
     }
@@ -202,6 +236,97 @@ class BackgroundAudioPlayer: ObservableObject {
                 print("📬 Notification sent successfully")
             }
         }
+    }
+
+    // MARK: - Alarm Ringing Persistence
+    private func persistAlarmRinging(_ ringing: Bool) {
+        let ud = UserDefaults(suiteName: Self.appGroupID)
+        ud?.set(ringing, forKey: Self.isAlarmRingingKey)
+        if ringing {
+            ud?.set(Date().timeIntervalSince1970, forKey: Self.alarmRingingTimestampKey)
+        } else {
+            ud?.removeObject(forKey: Self.alarmRingingTimestampKey)
+            ud?.removeObject(forKey: Self.originalVolumeKey)
+        }
+    }
+
+    /// 강제 종료 후 재실행 시 알람 상태 확인 (30분 이내만 유효)
+    static func isAlarmRingingPersisted() -> Bool {
+        let ud = UserDefaults(suiteName: appGroupID)
+        guard ud?.bool(forKey: isAlarmRingingKey) == true,
+              let timestamp = ud?.double(forKey: alarmRingingTimestampKey),
+              timestamp > 0
+        else { return false }
+
+        let elapsed = Date().timeIntervalSince1970 - timestamp
+        // burst 60개 × 30초 = 1800초(30분) 이내만 유효
+        return elapsed < Double(burstCount) * burstIntervalSec
+    }
+
+    /// 영속화된 알람 상태 초기화
+    static func clearAlarmRingingPersistence() {
+        let ud = UserDefaults(suiteName: appGroupID)
+        ud?.set(false, forKey: isAlarmRingingKey)
+        ud?.removeObject(forKey: alarmRingingTimestampKey)
+        ud?.removeObject(forKey: originalVolumeKey)
+    }
+
+    /// 영속화된 원래 시스템 볼륨 복원
+    func restoreOriginalVolumeFromPersistence() {
+        if let saved = UserDefaults(suiteName: Self.appGroupID)?.double(forKey: Self.originalVolumeKey),
+           saved > 0 {
+            originalSystemVolume = Float(saved)
+        } else {
+            originalSystemVolume = getCurrentSystemVolume()
+        }
+    }
+
+    // MARK: - Alarm Burst Notifications (강제 종료 대비)
+    private func scheduleAlarmBurst() {
+        let center = UNUserNotificationCenter.current()
+
+        // 기존 burst 취소
+        cancelAlarmBurst()
+
+        for i in 0..<Self.burstCount {
+            let content = UNMutableNotificationContent()
+            content.title = "CRock"
+            content.body = NSLocalizedString("alarm_notification_body", comment: "돌 깨러가기 🪨")
+            content.userInfo = ["targetScreen": "BreakingStone"]
+            content.sound = UNNotificationSound(named: .init("NotiSound28sec.caf"))
+
+            if #available(iOS 15.0, *) {
+                content.interruptionLevel = .timeSensitive
+            }
+
+            let delay = Self.burstIntervalSec * Double(i + 1) // 30, 60, 90 ...
+            let trigger = UNTimeIntervalNotificationTrigger(timeInterval: delay, repeats: false)
+            let request = UNNotificationRequest(
+                identifier: "\(Self.burstIdentifierPrefix)\(i)",
+                content: content,
+                trigger: trigger
+            )
+            center.add(request)
+        }
+        lastBurstScheduleTime = Date()
+        print("📬 Alarm burst scheduled: \(Self.burstCount) notifications")
+    }
+
+    func cancelAlarmBurst() {
+        let ids = (0..<Self.burstCount).map { "\(Self.burstIdentifierPrefix)\($0)" }
+        let center = UNUserNotificationCenter.current()
+        center.removePendingNotificationRequests(withIdentifiers: ids)
+        center.removeDeliveredNotifications(withIdentifiers: ids)
+        lastBurstScheduleTime = nil
+        print("🗑️ Alarm burst cancelled")
+    }
+
+    /// 앱이 살아있는 동안 burst를 계속 뒤로 밀어서 발사 방지 (Dead Man's Switch)
+    private func refreshBurstIfNeeded() {
+        guard isAlarmMode else { return }
+        // 5초마다 burst 재예약
+        if let last = lastBurstScheduleTime, Date().timeIntervalSince(last) < 5 { return }
+        scheduleAlarmBurst()
     }
 
     // MARK: - Volume Restoration Timer
@@ -253,6 +378,8 @@ class BackgroundAudioPlayer: ObservableObject {
             // 알람 모드일 때는 경고 노티 취소
             UNUserNotificationCenter.current()
                 .removePendingNotificationRequests(withIdentifiers: ["appTerminationWarning"])
+            // burst 노티를 계속 뒤로 밀어서 앱 살아있는 동안은 발사 안 되게
+            refreshBurstIfNeeded()
         }
 
         let now = Date()
@@ -322,6 +449,10 @@ class BackgroundAudioPlayer: ObservableObject {
         audioPlayer?.volume = 0.0
         isAlarmMode = false
 
+        // 영속화 상태 초기화 + burst 취소
+        persistAlarmRinging(false)
+        cancelAlarmBurst()
+
         // 다음 알람 시간 계산
         if let alarmTime = alarmTime {
             let comps = Calendar.current.dateComponents([.hour, .minute], from: alarmTime)
@@ -349,6 +480,10 @@ class BackgroundAudioPlayer: ObservableObject {
         isPlaying = false
         isAlarmMode = false
         alarmTime = nil
+
+        // 영속화 상태 초기화 + burst 취소
+        persistAlarmRinging(false)
+        cancelAlarmBurst()
 
         // 알람 끄면 종료 경고 노티도 취소
         UNUserNotificationCenter.current()

--- a/T8-NoFrank/Sources/Models/NotificationExtension.swift
+++ b/T8-NoFrank/Sources/Models/NotificationExtension.swift
@@ -163,6 +163,7 @@ extension NotificationDelegate {
                 AppRouter.shared.navigate(.home)
             }
         } else {
+            // burst 노티 또는 일반 알람 노티 → 돌 깨기 화면으로
             Task { @MainActor in
                 AppRouter.shared.navigate(.breakingStone)
             }

--- a/T8-NoFrank/Sources/Models/NotificationService.swift
+++ b/T8-NoFrank/Sources/Models/NotificationService.swift
@@ -52,8 +52,9 @@ final class NotificationDelegate: NSObject, UNUserNotificationCenterDelegate {
         withCompletionHandler completionHandler:
             @escaping (UNNotificationPresentationOptions) -> Void
     ) {
-        // 앱이 살아있는 상태에서는 종료 경고 알림을 표시하지 않음
-        if notification.request.identifier == "appTerminationWarning" {
+        let id = notification.request.identifier
+        // 앱이 살아있는 상태에서는 종료 경고/burst 알림을 표시하지 않음
+        if id == "appTerminationWarning" || id.hasPrefix("ALARM_BURST_") {
             completionHandler([])
             return
         }

--- a/T8-NoFrank/Sources/Views/BlowAwayStone/BlowAwayStoneView.swift
+++ b/T8-NoFrank/Sources/Views/BlowAwayStone/BlowAwayStoneView.swift
@@ -162,6 +162,8 @@ struct BlowAwayStoneView: View {
 
             try? await Task.sleep(for: .seconds(2))
             guard !Task.isCancelled else { return }
+            // 알람 정지 + burst 노티 정리 + 퍼시스턴스 초기화
+            BackgroundAudioPlayer.shared.stopAlarmAndBackToSilent()
             AppRouter.shared.navigate(.home)
         }
     }

--- a/T8-NoFrank/Sources/Views/Home/HomeView.swift
+++ b/T8-NoFrank/Sources/Views/Home/HomeView.swift
@@ -305,7 +305,8 @@ struct HomeView: View {
         }
 
         // 앱 시작 시 백그라운드 오디오 복원
-        if isEnabled {
+        // 알람이 울리는 중이면 silent sound 재시작하지 않음 (T8_NoFrankApp에서 breakingStone으로 이동)
+        if isEnabled && !BackgroundAudioPlayer.isAlarmRingingPersisted() {
             let comps = Calendar.current.dateComponents([.hour, .minute], from: alarmTime)
             let hour = comps.hour ?? 0
             let minute = comps.minute ?? 0


### PR DESCRIPTION
## ✨ What's this PR?
### 📌 관련 이슈 (Related Issue)
- Closes #104

---

### 🧶 주요 변경 내용 (Summary)

#### 알람 상태 영속화
- UserDefaults(AppGroup)에 알람 울림 상태, 타임스탬프, 원래 볼륨 저장
- 강제 종료 후 재실행 시 30분 이내면 알람 복원 가능

#### Burst 노티 스케줄링 (강제 종료 대비)
- 알람 시작 시 30초 간격 × 60개 로컬 노티 예약 (30분 커버)
- 앱 생존 중 5초마다 재스케줄 → 앱이 살아있으면 발동 안 됨, 종료되면 자동 발동
- 포그라운드에서 ALARM_BURST 노티 배너 표시되지 않도록 필터링

#### 앱 재진입 시 알람 복원
- scenePhase .active에서 영속화 상태 확인 → 볼륨 복원 + 알람 재생 + 돌깨기 화면 이동
- HomeView: 알람 울리는 중이면 startSilentSound 스킵
- BlowAwayStoneView: 돌 깨기 완료 시 burst 취소 + 상태 초기화

---

### 🧪 테스트 / 검증 내역

- [x] 알람 중 강제 종료 → burst 노티 수신 확인
- [x] burst 노티 탭 → 앱 재진입 → 알람 재생 + 돌깨기 화면 이동 확인
- [x] 돌 깨기 완료 후 burst 노티 중단 + 볼륨 복원 확인
- [x] 앱 살아있는 동안 burst 노티 배너 안 뜨는지 확인
- [ ] 30분 이후 burst 노티 자연 종료 확인
- [ ] UI 정상 동작 확인
- [x] 핸드폰 빌드 후 확인