### PR TITLE
🍀 Chore: #135 PR 시 테스트 코드 자동 실행 워크플로우 추가

### DIFF
--- a/.github/workflows/ios-tests.yml
+++ b/.github/workflows/ios-tests.yml
@@ -1,0 +1,60 @@
+name: iOS Tests
+
+on:
+  pull_request:
+    branches: [develop]
+  workflow_dispatch:
+
+# 같은 PR에서 새 커밋이 push되면 이전 실행은 취소
+concurrency:
+  group: ios-tests-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: macos-26
+    timeout-minutes: 30
+    env:
+      CI: true
+      # fastlane는 simctl 출력을 파싱할 때 UTF-8 로케일을 요구 (미설정 시 simctl 파싱 깨짐)
+      LANG: en_US.UTF-8
+      LC_ALL: en_US.UTF-8
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Select Xcode 26.4.1
+        run: sudo xcode-select -s /Applications/Xcode_26.4.1.app
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: Pick simulator
+        id: sim
+        run: |
+          # 러너에 설치된 iPhone 시뮬레이터 중 가장 최신 모델을 선택 (없으면 폴백)
+          NAME=$(xcrun simctl list devices available \
+            | sed -nE 's/^ +(iPhone [0-9]+) \(.*/\1/p' \
+            | sort -V -u | tail -1)
+          NAME=${NAME:-iPhone 17}
+          echo "Selected simulator: $NAME"
+          echo "name=$NAME" >> "$GITHUB_OUTPUT"
+
+      - name: Run unit tests
+        env:
+          TEST_SIMULATOR: ${{ steps.sim.outputs.name }}
+        run: bundle exec fastlane ios tests
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-output
+          path: |
+            fastlane/test_output/**
+            **/*.xcresult
+          if-no-files-found: ignore
+          retention-days: 7

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -6,6 +6,24 @@ Dotenv.load('.env.dev') unless ENV['CI']
 default_platform(:ios)
 
 platform :ios do
+  desc "PR 검증용 단위 테스트 실행 (시뮬레이터, 서명 불필요)"
+  lane :tests do
+    setup_ci if is_ci
+
+    # 시뮬레이터 이름은 워크플로우에서 TEST_SIMULATOR로 주입. 없으면 iPhone 17로 폴백.
+    device = (ENV["TEST_SIMULATOR"].to_s.strip.empty? ? "iPhone 17" : ENV["TEST_SIMULATOR"].strip)
+
+    run_tests(
+      project: "T8-NoFrank.xcodeproj",
+      scheme: "T8-NoFrank",
+      devices: [device],
+      clean: true,
+      code_coverage: false,
+      # 시뮬레이터 테스트는 서명 불필요 → 서명 시도 자체를 끔
+      xcargs: "CODE_SIGNING_ALLOWED=NO"
+    )
+  end
+
   lane :beta do
     setup_ci if is_ci
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -13,10 +13,14 @@ platform :ios do
     # 시뮬레이터 이름은 워크플로우에서 TEST_SIMULATOR로 주입. 없으면 iPhone 17로 폴백.
     device = (ENV["TEST_SIMULATOR"].to_s.strip.empty? ? "iPhone 17" : ENV["TEST_SIMULATOR"].strip)
 
+    # destination을 직접 넘기고 자동 탐지를 끈다.
+    # (fastlane 2.230.0는 Xcode 26.4.1의 `xcrun simctl runtime match list` 출력 파싱이 깨져,
+    #  devices: 로 자동 탐지시키면 run_tests가 실패함. 배포 레인 영향 없이 우회하려면 여기서 끈다.)
     run_tests(
       project: "T8-NoFrank.xcodeproj",
       scheme: "T8-NoFrank",
-      devices: [device],
+      destination: "platform=iOS Simulator,name=#{device}",
+      skip_detect_devices: true,
       clean: true,
       code_coverage: false,
       # 시뮬레이터 테스트는 서명 불필요 → 서명 시도 자체를 끔

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -15,6 +15,14 @@ For _fastlane_ installation instructions, see [Installing _fastlane_](https://do
 
 ## iOS
 
+### ios tests
+
+```sh
+[bundle exec] fastlane ios tests
+```
+
+PR 검증용 단위 테스트 실행 (시뮬레이터, 서명 불필요)
+
 ### ios beta
 
 ```sh


### PR DESCRIPTION
## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
- Closes #135

---

### 🧶 주요 변경 내용 (Summary)

- `.github/workflows/ios-tests.yml` 추가 — `pull_request`(base: develop) + 수동 실행 시 `T8-NoFrankTests` 단위 테스트를 시뮬레이터에서 자동 실행
- fastlane `tests` 레인 추가 — `run_tests`로 `T8-NoFrank` 스킴 테스트. 시뮬레이터라 코드 서명 불필요 → `CODE_SIGNING_ALLOWED=NO`, match/secrets 미사용
- 러너에 설치된 최신 iPhone 시뮬레이터를 동적 선택(폴백 `iPhone 17`)
- `LANG`/`LC_ALL`을 UTF-8로 지정 — 미설정 시 fastlane의 `simctl` 출력 파싱이 깨지는 문제 방어

러너/Xcode 버전(macos-26 / Xcode 26.4.1)은 기존 `testflight-build.yml`에 맞춤.

---

### 🧪 테스트 / 검증 내역

- [x] 로컬 `fastlane ios tests` 실행 → 16개 테스트 통과 (Test Succeeded)
- [x] 본 PR의 GitHub Actions에서 테스트 통과 확인