### PR TITLE
🍀 Chore: #137 개발용 알람 즉시 울리기/종료 디버그 메뉴 추가 (DEBUG 한정)

### DIFF
--- a/T8-NoFrank/Sources/Views/BreakingStone/BreakingStoneView.swift
+++ b/T8-NoFrank/Sources/Views/BreakingStone/BreakingStoneView.swift
@@ -44,6 +44,9 @@ struct BreakingStoneView: View {
                 alarmMinute = minute
             }
         }
+        #if DEBUG
+        .debugAlarmOverlay()
+        #endif
     }
 }
 

--- a/T8-NoFrank/Sources/Views/Component/DebugAlarmMenu.swift
+++ b/T8-NoFrank/Sources/Views/Component/DebugAlarmMenu.swift
@@ -29,7 +29,7 @@ struct DebugAlarmMenu: View {
                 BackgroundAudioPlayer.shared.stopAlarmAndBackToSilent()
                 AppRouter.shared.navigate(.home)
             } label: {
-                Label("알람 종료하기", systemImage: "alarm.slash.fill")
+                Label("알람 종료하기", systemImage: "stop.circle.fill")
             }
         } label: {
             Image(systemName: "ladybug.fill")

--- a/T8-NoFrank/Sources/Views/Component/DebugAlarmMenu.swift
+++ b/T8-NoFrank/Sources/Views/Component/DebugAlarmMenu.swift
@@ -1,0 +1,62 @@
+//
+//  DebugAlarmMenu.swift
+//  T8-NoFrank
+//
+//  개발용 디버그 메뉴. `#if DEBUG` 가드로 Release/TestFlight 빌드에는 컴파일되지 않는다.
+//  알람이 실제로 울릴 때까지 1분을 기다리지 않고, 버튼으로 즉시 울리고/끄기 위한 테스트 도구.
+//
+
+#if DEBUG
+import SwiftUI
+
+/// 우상단 툴바 위치에 뜨는 디버그 서랍(Menu).
+/// 벌레 아이콘을 누르면 "알람 울리기 / 알람 종료하기" 두 액션이 펼쳐진다.
+/// HomeView·BreakingStoneView 양쪽에 얹어, 어느 화면에서든 즉시 켜고 끌 수 있다.
+struct DebugAlarmMenu: View {
+    var body: some View {
+        Menu {
+            Button {
+                // 실제 알람 발동 경로를 그대로 호출 → 즉시 울림 + 돌 깨기 화면 진입
+                BackgroundAudioPlayer.shared.playAlarmSound()
+                AppRouter.shared.navigate(.breakingStone)
+            } label: {
+                Label("알람 울리기", systemImage: "alarm.fill")
+            }
+
+            Button(role: .destructive) {
+                // 돌 깨기 성공과 동일하게 알람 정지 + 무음 복귀 후 홈으로
+                BackgroundAudioPlayer.shared.stopAlarmAndBackToSilent()
+                AppRouter.shared.navigate(.home)
+            } label: {
+                Label("알람 종료하기", systemImage: "alarm.slash.fill")
+            }
+        } label: {
+            Image(systemName: "ladybug.fill")
+                .font(.system(size: 18, weight: .bold))
+                .foregroundStyle(.white)
+                .padding(10)
+                .background(Circle().fill(Color.black.opacity(0.5)))
+        }
+        .accessibilityIdentifier("debugAlarmMenu")
+    }
+}
+
+extension View {
+    /// 어떤 화면이든 우상단 안전영역에 디버그 메뉴를 얹는다.
+    /// 배포 빌드에서 흔적을 남기지 않도록 호출부도 `#if DEBUG`로 감싼다.
+    ///
+    /// GeometryReader로 실제 safe area top을 읽어 위치를 잡는다.
+    /// - 부모가 `.ignoresSafeArea`면 safeAreaInsets.top이 노치 높이(~59)로 잡혀 그만큼 내려가고,
+    /// - 부모가 safe area를 지키면 top이 ~0이라, 두 화면 모두 노치 바로 아래 툴바 위치에 정렬된다.
+    func debugAlarmOverlay() -> some View {
+        overlay(alignment: .topTrailing) {
+            GeometryReader { proxy in
+                DebugAlarmMenu()
+                    .padding(.top, proxy.safeAreaInsets.top + 8)
+                    .padding(.trailing, 16)
+                    .frame(maxWidth: .infinity, alignment: .topTrailing)
+            }
+        }
+    }
+}
+#endif

--- a/T8-NoFrank/Sources/Views/Component/DebugAlarmMenu.swift
+++ b/T8-NoFrank/Sources/Views/Component/DebugAlarmMenu.swift
@@ -8,6 +8,7 @@
 
 #if DEBUG
 import SwiftUI
+import UIKit
 
 /// 우상단 툴바 위치에 뜨는 디버그 서랍(Menu).
 /// 벌레 아이콘을 누르면 "알람 울리기 / 알람 종료하기" 두 액션이 펼쳐진다.
@@ -41,21 +42,26 @@ struct DebugAlarmMenu: View {
     }
 }
 
+/// 실제 윈도우의 상단 safe area inset(노치/다이내믹 아일랜드 높이).
+///
+/// SwiftUI의 `GeometryReader.safeAreaInsets`는 부모가 `.ignoresSafeArea`면 0으로 잡혀
+/// 오버레이가 노치 위로 올라가버린다. 그래서 SwiftUI 계층이 아닌 UIKit 윈도우에서 직접 읽는다.
+private var deviceTopSafeAreaInset: CGFloat {
+    UIApplication.shared.connectedScenes
+        .compactMap { $0 as? UIWindowScene }
+        .flatMap { $0.windows }
+        .first { $0.isKeyWindow }?
+        .safeAreaInsets.top ?? 0
+}
+
 extension View {
-    /// 어떤 화면이든 우상단 안전영역에 디버그 메뉴를 얹는다.
+    /// 어떤 화면이든 우상단 안전영역 안쪽(노치 바로 아래 툴바 위치)에 디버그 메뉴를 얹는다.
     /// 배포 빌드에서 흔적을 남기지 않도록 호출부도 `#if DEBUG`로 감싼다.
-    ///
-    /// GeometryReader로 실제 safe area top을 읽어 위치를 잡는다.
-    /// - 부모가 `.ignoresSafeArea`면 safeAreaInsets.top이 노치 높이(~59)로 잡혀 그만큼 내려가고,
-    /// - 부모가 safe area를 지키면 top이 ~0이라, 두 화면 모두 노치 바로 아래 툴바 위치에 정렬된다.
     func debugAlarmOverlay() -> some View {
         overlay(alignment: .topTrailing) {
-            GeometryReader { proxy in
-                DebugAlarmMenu()
-                    .padding(.top, proxy.safeAreaInsets.top + 8)
-                    .padding(.trailing, 16)
-                    .frame(maxWidth: .infinity, alignment: .topTrailing)
-            }
+            DebugAlarmMenu()
+                .padding(.top, deviceTopSafeAreaInset + 8)
+                .padding(.trailing, 16)
         }
     }
 }

--- a/T8-NoFrank/Sources/Views/Home/HomeView.swift
+++ b/T8-NoFrank/Sources/Views/Home/HomeView.swift
@@ -181,6 +181,9 @@ struct HomeView: View {
             }
             WidgetCenter.shared.reloadAllTimelines()
         }
+        #if DEBUG
+        .debugAlarmOverlay()
+        #endif
     }
 
     private var timeTextFormatted: String {


### PR DESCRIPTION
## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
- Closes #137

---

### 🧶 주요 변경 내용 (Summary)

기능 테스트 시 알람 시각 도달까지 1분을 기다리지 않도록, Debug 빌드 전용 디버그 메뉴를 추가함.

- `DebugAlarmMenu` 신규 — 우상단 툴바 위치에 벌레 아이콘, 누르면 디스클로저(Menu)로 두 액션 노출
  - `알람 울리기`: `BackgroundAudioPlayer.playAlarmSound()` + `AppRouter.navigate(.breakingStone)` — 실제 발동 경로 그대로 호출해 즉시 울림 + 돌 깨기 화면 진입
  - `알람 종료하기`: `BackgroundAudioPlayer.stopAlarmAndBackToSilent()` + `AppRouter.navigate(.home)` — 돌 깨기 성공과 동일하게 알람 정지 후 홈 복귀
- `HomeView`, `BreakingStoneView` 양쪽에 오버레이 → 메인에서도, 알람 울리는 화면에서도 보이며 즉시 끌 수 있음
- 위치는 GeometryReader로 safe area top을 읽어 두 화면 모두 노치 아래 툴바 위치에 정렬

기존 알람 로직 함수는 호출만 하고 수정하지 않음(동작 재현용).

### 🔒 Release 안전장치

- 전체를 `#if DEBUG`로 가드 → Release/TestFlight 빌드에는 코드 자체가 컴파일되지 않음
- Debug / Release 두 configuration 모두 시뮬레이터 빌드 성공 확인 (Release는 디버그 코드 제외 상태로 빌드됨)

---

### 📸 스크린샷 (Optional)
<!-- 빌드 후 디버그 메뉴 화면 첨부 예정 -->

https://github.com/user-attachments/assets/fef49254-f70f-4ecb-9c00-076c4ad99c34


---

### 🧪 테스트 / 검증 내역

- [x] Debug 빌드 컴파일 성공 (시뮬레이터)
- [x] Release 빌드 컴파일 성공 → `#if DEBUG` 가드로 디버그 코드 미포함 확인
- [x] 실기기/시뮬레이터에서 `알람 울리기` → 즉시 사운드 + 돌 깨기 화면 확인
- [x] `알람 종료하기` → 알람 정지 + 홈 복귀 확인
- [x] 알람 울리는 화면에서도 디버그 메뉴로 즉시 종료 확인